### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/realgolfgames/docs/security/code-scanning/1](https://github.com/realgolfgames/docs/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the least privileges required. Based on the workflow's tasks:
- The `build` job only needs `contents: read` to check out the repository and build the documentation.
- The `trigger-deploy` job requires `contents: read` for repository access and no additional permissions for triggering the deployment via a webhook.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
